### PR TITLE
fix: 更新BV号的正则匹配规则

### DIFF
--- a/ibili.js
+++ b/ibili.js
@@ -199,7 +199,7 @@ const ibili = (function(){
         },
         get_bvid: function(url){
             if(this.isbvidurl(url)){
-                return url.match(/\/([^/]+?)\?/)[1]
+                return url.match(/BV?(\w*)/)[0]
             }else{
                 throw new Error('is not bvid url...')
             }


### PR DESCRIPTION
之前的BV号匹配规则不适用现在的URl了
测试URL：
1. https://www.bilibili.com/video/BV1MM411c7m6?p=1&vd_source=9aa07a4ab7c51088758aea91d77068a4
2. https://www.bilibili.com/video/BV1MM411c7m6/?vd_source=9aa07a4ab7c51088758aea91d77068a4